### PR TITLE
Remove extra parenthesis

### DIFF
--- a/R/stat_theodensity.R
+++ b/R/stat_theodensity.R
@@ -45,7 +45,7 @@
 #'   doubles that can be divided by 1 without remainders.
 #'
 #'   Parameters are estimated using the
-#'   [fitdistrplus::fitdist()]`()` function in the
+#'   [fitdistrplus::fitdist()] function in the
 #'   \pkg{fitdistrplus} package using maximum likelihood estimation.
 #'   Hypergeometric and multinomial distributions from the \pkg{stats} package
 #'   are not supported.

--- a/man/stat_theodensity.Rd
+++ b/man/stat_theodensity.Rd
@@ -146,7 +146,7 @@ For discrete distributions, the input data are expected to be integers, or
 doubles that can be divided by 1 without remainders.
 
 Parameters are estimated using the
-\code{\link[fitdistrplus:fitdist]{fitdistrplus::fitdist()}}\verb{()} function in the
+\code{\link[fitdistrplus:fitdist]{fitdistrplus::fitdist()}} function in the
 \pkg{fitdistrplus} package using maximum likelihood estimation.
 Hypergeometric and multinomial distributions from the \pkg{stats} package
 are not supported.


### PR DESCRIPTION
Hi,

Thanks for the package, it is very useful.

When reading the documentation of `stat_theodensity`, I saw some extra parentheses in the last paragraph of the "Details" section.
It looks like these extra parentheses were introduced by the conversion to roxygen md. This PR removes them.