### PR TITLE
Independent placement of labels in `coord_axes_inside()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Suggests:
 VignetteBuilder: 
     knitr
 Encoding: UTF-8
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Config/testthat/edition: 3
 Collate:
     'at_panel.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # ggh4x (development version)
 
+* `coord_axis_inside(labels_inside)` now supports independent `"x"` and `"y"` 
+  (#167).
 * Fixed bug in label remover (#158).
 * Fixed bug in axis `check.overlap` setting (#165).
 * Future-proofing of wrapped facets.

--- a/R/coord_axes_inside.R
+++ b/R/coord_axes_inside.R
@@ -15,9 +15,10 @@ NULL
 #' @param xintercept,yintercept A `numeric(1)` for the positions where the
 #'   orthogonal axes should be placed. If these are outside the bounds of the
 #'   limits, the axes are placed to the nearest extreme.
-#' @param labels_inside A `logical(1)` when labels should be placed inside the
-#'   panel along the axes (`TRUE`) or placed outside the panel
-#'   (`FALSE`, default).
+#' @param labels_inside One of `"x"`, `"y"`, `"both"` or `"none"` specifying
+#'   the axes where labels should be placed inside the panel along the axes.
+#'   `TRUE` is translated as `"both"` and `FALSE` (default) is translated as
+#'   `"none"`.
 #' @param ratio Either `NULL`, or a `numeric(1)` for a fixed aspect ratio,
 #'   expressed as `y / x`.
 #'

--- a/R/coord_axes_inside.R
+++ b/R/coord_axes_inside.R
@@ -54,6 +54,13 @@ coord_axes_inside <- function(
   clip = "on"
 ) {
 
+  if (is.character(labels_inside)) {
+    labels_inside <- arg_match0(labels_inside, c("x", "y", "none", "both"))
+  } else {
+    labels_inside <- if (isTRUE(labels_inside)) "both" else "none"
+  }
+
+  inner_axes <- theme()
   outer_axes <- theme(
     axis.line.x.bottom  = element_blank(),
     axis.line.x.top     = element_blank(),
@@ -64,35 +71,42 @@ coord_axes_inside <- function(
     axis.ticks.y.left   = element_blank(),
     axis.ticks.y.right  = element_blank()
   )
-  if (isTRUE(labels_inside)) {
+
+  if (labels_inside %in% c("x", "both")) {
     outer_axes <- outer_axes + theme(
-      axis.text.x.bottom = element_blank(),
-      axis.text.x.top    = element_blank(),
-      axis.text.y.left   = element_blank(),
-      axis.text.y.right  = element_blank(),
+      axis.text.x.bottom         = element_blank(),
+      axis.text.x.top            = element_blank(),
       axis.ticks.length.x.bottom = unit(0, "pt"),
       axis.ticks.length.x.top    = unit(0, "pt"),
-      axis.ticks.length.y.left   = unit(0, "pt"),
-      axis.ticks.length.y.right  = unit(0, "pt")
     )
-    inner_axes <- theme()
   } else {
-    inner_axes <- theme(
+    inner_axes <- inner_axes + theme(
       axis.text.x.bottom = element_blank(),
-      axis.text.x.top    = element_blank(),
-      axis.text.y.left   = element_blank(),
-      axis.text.y.right  = element_blank()
+      axis.text.x.top    = element_blank()
+    )
+  }
+  if (labels_inside %in% c("y", "both")) {
+    outer_axes <- outer_axes + theme(
+      axis.text.y.left          = element_blank(),
+      axis.text.y.right         = element_blank(),
+      axis.ticks.length.y.left  = unit(0, "pt"),
+      axis.ticks.length.y.right = unit(0, "pt")
+    )
+  } else {
+    inner_axes <- inner_axes + theme(
+      axis.text.y.left  = element_blank(),
+      axis.text.y.right = element_blank()
     )
   }
 
   ggproto(
     NULL, CoordAxesInside,
-    limits  = list(x = xlim, y = ylim),
-    expand  = expand,
-    default = default,
-    clip    = clip,
-    ratio   = ratio,
-    origin  = data_frame0(x = xintercept[1], y = yintercept[1]),
+    limits     = list(x = xlim, y = ylim),
+    expand     = expand,
+    default    = default,
+    clip       = clip,
+    ratio      = ratio,
+    origin     = data_frame0(x = xintercept[1], y = yintercept[1]),
     outer_axes = outer_axes,
     inner_axes = inner_axes
   )

--- a/man/coord_axes_inside.Rd
+++ b/man/coord_axes_inside.Rd
@@ -23,9 +23,10 @@ coord_axes_inside(
 orthogonal axes should be placed. If these are outside the bounds of the
 limits, the axes are placed to the nearest extreme.}
 
-\item{labels_inside}{A \code{logical(1)} when labels should be placed inside the
-panel along the axes (\code{TRUE}) or placed outside the panel
-(\code{FALSE}, default).}
+\item{labels_inside}{One of \code{"x"}, \code{"y"}, \code{"both"} or \code{"none"} specifying
+the axes where labels should be placed inside the panel along the axes.
+\code{TRUE} is translated as \code{"both"} and \code{FALSE} (default) is translated as
+\code{"none"}.}
 
 \item{ratio}{Either \code{NULL}, or a \code{numeric(1)} for a fixed aspect ratio,
 expressed as \code{y / x}.}


### PR DESCRIPTION
This PR aims to fix #167.

``` r
devtools::load_all("~/packages/ggh4x/")
#> ℹ Loading ggh4x
#> Loading required package: ggplot2

dat <- expand.grid(
  id = letters[1:3],
  time = 1:50 * 2
) |> cbind(y = rnorm(150))

ggplot(dat, aes(x = time, y = y)) +
  geom_line() +
  facet_grid(cols = vars(id)) +
  coord_axes_inside(labels_inside = "x") +
  theme_classic()
```

![](https://i.imgur.com/E2EQsEM.png)<!-- -->

<sup>Created on 2024-11-16 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
